### PR TITLE
fix: run commit filtering from git root

### DIFF
--- a/packages/multi-semantic-release/lib/get-commits-filtered.js
+++ b/packages/multi-semantic-release/lib/get-commits-filtered.js
@@ -48,6 +48,7 @@ async function getCommitsFiltered(cwd, direction, lastRelease, nextRelease, firs
 
     // Get top-level Git directory as it might be higher up the tree than cwd.
     const root = await execa("git", ["rev-parse", "--show-toplevel"], { cwd });
+    const gitRoot = cleanPath(root.stdout);
 
     // Add correct fields to gitLogParser.
     Object.assign(gitLogParser.fields, {
@@ -58,11 +59,11 @@ async function getCommitsFiltered(cwd, direction, lastRelease, nextRelease, firs
     });
 
     // Use git-log-parser to get the commits.
-    const relpath = relative(root.stdout, direction);
+    const relpath = relative(gitRoot, direction);
     const firstParentBranchFilter = firstParentBranch ? ["--first-parent", firstParentBranch] : [];
     const range = (lastRelease ? `${lastRelease}..` : "") + (nextRelease || "HEAD");
     const gitLogFilterQuery = [...firstParentBranchFilter, range, "--", relpath];
-    const stream = gitLogParser.parse({ _: gitLogFilterQuery }, { cwd, env: process.env });
+    const stream = gitLogParser.parse({ _: gitLogFilterQuery }, { cwd: gitRoot, env: process.env });
 
     const commits = await streamToArray(stream);
 


### PR DESCRIPTION
## Summary
- resolve the git repository root before calling `git log`
- run git-log-parser in that root so workspace packages living under nested directories still surface commits

## Testing
- pnpm vitest run __tests__/lib/get-commits-filtered.test.js
- pnpm --filter @anolilab/multi-semantic-release test  # currently fails on origin/main with `fatal: couldn't find remote ref HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git repository path resolution to ensure consistent operation regardless of the working directory from which the tool is invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->