### PR TITLE
fix(semantic-release-pnpm): use pnpm whoami for custom registry auth verification

### DIFF
--- a/packages/semantic-release-pnpm/__tests__/unit/verify/verify-auth.test.ts
+++ b/packages/semantic-release-pnpm/__tests__/unit/verify/verify-auth.test.ts
@@ -108,7 +108,8 @@ describe(verifyAuth, () => {
     it("should throw EINVALIDNPMTOKEN when whoami fails for custom registry", async () => {
         expect.assertions(3);
 
-        const customRegistry = "https://custom.registry.org/";
+        // Use a distinct registry to avoid hitting the whoamiCache populated by the preceding test
+        const customRegistry = "https://failing.registry.org/";
 
         vi.mocked(getRegistry).mockReturnValue(customRegistry);
         vi.mocked(oidcContextEstablished).mockResolvedValue(false);
@@ -116,7 +117,7 @@ describe(verifyAuth, () => {
 
         vi.mocked(execa).mockRejectedValue(
             Object.assign(new Error("Command failed"), {
-                stderr: "This command requires you to be logged in to https://custom.registry.org/",
+                stderr: "This command requires you to be logged in to https://failing.registry.org/",
                 stdout: "",
             }) as Error & { stderr: string; stdout: string },
         );

--- a/packages/semantic-release-pnpm/__tests__/unit/verify/verify-auth.test.ts
+++ b/packages/semantic-release-pnpm/__tests__/unit/verify/verify-auth.test.ts
@@ -127,11 +127,12 @@ describe(verifyAuth, () => {
     });
 
     it("should not fail when the package version already exists in a custom registry", async () => {
-        expect.assertions(2);
+        expect.assertions(3);
 
-        const customRegistry = "https://custom.registry.org/";
+        // Use a distinct registry to avoid hitting the cache populated by the preceding test
+        const alreadyPublishedRegistry = "https://already-published.registry.org/";
 
-        vi.mocked(getRegistry).mockReturnValue(customRegistry);
+        vi.mocked(getRegistry).mockReturnValue(alreadyPublishedRegistry);
         vi.mocked(oidcContextEstablished).mockResolvedValue(false);
         vi.mocked(setNpmrcAuth).mockResolvedValue(undefined);
 
@@ -139,7 +140,12 @@ describe(verifyAuth, () => {
         vi.mocked(execa).mockResolvedValue({ stderr: "", stdout: "test-user" } as any);
 
         await expect(verifyAuth(npmrc, pkg, context)).resolves.toBeUndefined();
-        expect(execa).toHaveBeenCalledWith("pnpm", ["whoami", "--registry", customRegistry], expect.any(Object));
+
+        // The regression guard: old code used `pnpm publish --dry-run`, which fails when the
+        // version already exists. New code uses `whoami` exclusively, so that error path
+        // is unreachable regardless of the registry's publish state.
+        expect(execa).toHaveBeenCalledWith("pnpm", ["whoami", "--registry", alreadyPublishedRegistry], expect.any(Object));
+        expect(execa).not.toHaveBeenCalledWith("pnpm", expect.arrayContaining(["publish", "--dry-run"]), expect.any(Object));
     });
 
     it("should verify auth when package name is missing", async () => {

--- a/packages/semantic-release-pnpm/__tests__/unit/verify/verify-auth.test.ts
+++ b/packages/semantic-release-pnpm/__tests__/unit/verify/verify-auth.test.ts
@@ -73,7 +73,7 @@ describe(verifyAuth, () => {
         expect(setNpmrcAuth).toHaveBeenCalledWith(npmrc, OFFICIAL_REGISTRY, context);
     });
 
-    it("should perform dry-run publish for custom registries", async () => {
+    it("should perform whoami for custom registries", async () => {
         expect.assertions(4);
 
         const customRegistry = "https://custom.registry.org/";
@@ -83,16 +83,16 @@ describe(verifyAuth, () => {
         vi.mocked(setNpmrcAuth).mockResolvedValue(undefined);
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-        vi.mocked(execa).mockResolvedValue({ stderr: "some output", stdout: "" } as any);
+        vi.mocked(execa).mockResolvedValue({ stderr: "", stdout: "test-user" } as any);
 
-        await verifyAuth(npmrc, pkg, context, "/dist");
+        await verifyAuth(npmrc, pkg, context);
 
-        expect(context.logger.log).toHaveBeenCalledWith(expect.stringContaining("Running \"pnpm publish --dry-run\" to verify authentication"));
+        expect(context.logger.log).toHaveBeenCalledWith(expect.stringContaining("Running \"pnpm whoami\" to verify authentication"));
         expect(oidcContextEstablished).toHaveBeenCalledWith(customRegistry, pkg, context);
         expect(setNpmrcAuth).toHaveBeenCalledWith(npmrc, customRegistry, context);
         expect(execa).toHaveBeenCalledWith(
             "pnpm",
-            ["publish", "/dist", "--dry-run", "--tag=semantic-release-auth-check", "--registry", customRegistry, "--no-git-checks"],
+            ["whoami", "--registry", customRegistry],
             {
                 cwd: context.cwd,
                 env: {
@@ -105,39 +105,7 @@ describe(verifyAuth, () => {
         );
     });
 
-    it("should perform dry-run publish for custom registries from a sub-directory", async () => {
-        expect.assertions(3);
-
-        const customRegistry = "https://custom.registry.org/";
-        const pkgRoot = "/dist";
-
-        vi.mocked(getRegistry).mockReturnValue(customRegistry);
-        vi.mocked(oidcContextEstablished).mockResolvedValue(false);
-        vi.mocked(setNpmrcAuth).mockResolvedValue(undefined);
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-        vi.mocked(execa).mockResolvedValue({ stderr: "some output", stdout: "" } as any);
-
-        await verifyAuth(npmrc, pkg, context, pkgRoot);
-
-        expect(oidcContextEstablished).toHaveBeenCalledWith(customRegistry, pkg, context);
-        expect(setNpmrcAuth).toHaveBeenCalledWith(npmrc, customRegistry, context);
-        expect(execa).toHaveBeenCalledWith(
-            "pnpm",
-            ["publish", "/dist", "--dry-run", "--tag=semantic-release-auth-check", "--registry", customRegistry, "--no-git-checks"],
-            {
-                cwd: context.cwd,
-                env: {
-                    ...context.env,
-                    NPM_CONFIG_USERCONFIG: npmrc,
-                },
-                preferLocal: true,
-                timeout: 5000,
-            },
-        );
-    });
-
-    it("should throw error when dry-run publish fails with auth error for custom registry", async () => {
+    it("should throw EINVALIDNPMTOKEN when whoami fails for custom registry", async () => {
         expect.assertions(3);
 
         const customRegistry = "https://custom.registry.org/";
@@ -153,9 +121,25 @@ describe(verifyAuth, () => {
             }) as Error & { stderr: string; stdout: string },
         );
 
-        await expect(verifyAuth(npmrc, pkg, context)).rejects.toThrow("Invalid npm authentication");
+        await expect(verifyAuth(npmrc, pkg, context)).rejects.toThrow("Invalid npm token");
         expect(oidcContextEstablished).toHaveBeenCalledWith(customRegistry, pkg, context);
         expect(setNpmrcAuth).toHaveBeenCalledWith(npmrc, customRegistry, context);
+    });
+
+    it("should not fail when the package version already exists in a custom registry", async () => {
+        expect.assertions(2);
+
+        const customRegistry = "https://custom.registry.org/";
+
+        vi.mocked(getRegistry).mockReturnValue(customRegistry);
+        vi.mocked(oidcContextEstablished).mockResolvedValue(false);
+        vi.mocked(setNpmrcAuth).mockResolvedValue(undefined);
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+        vi.mocked(execa).mockResolvedValue({ stderr: "", stdout: "test-user" } as any);
+
+        await expect(verifyAuth(npmrc, pkg, context)).resolves.toBeUndefined();
+        expect(execa).toHaveBeenCalledWith("pnpm", ["whoami", "--registry", customRegistry], expect.any(Object));
     });
 
     it("should verify auth when package name is missing", async () => {

--- a/packages/semantic-release-pnpm/src/verify/index.ts
+++ b/packages/semantic-release-pnpm/src/verify/index.ts
@@ -46,7 +46,7 @@ const verify = async (pluginConfig: PluginConfig, context: VerifyConditionsConte
 
             const npmrc = getNpmrcPath(context.cwd, context.env);
 
-            await verifyAuth(npmrc, packageJson, context, pluginConfig.pkgRoot);
+            await verifyAuth(npmrc, packageJson, context);
         } else {
             context.logger.log(`Skipping authentication verification for package "${packageJson.name ?? "unknown"}" (publishing disabled)`);
         }

--- a/packages/semantic-release-pnpm/src/verify/verify-auth.ts
+++ b/packages/semantic-release-pnpm/src/verify/verify-auth.ts
@@ -185,96 +185,80 @@ const verifyAuthContextAgainstRegistry = async (npmrc: string, registry: string,
     }
 };
 
-const AUTH_STATUS_401 = /\b401\b/;
-const AUTH_STATUS_403 = /\b403\b/;
-
 /**
- * Check if an error message indicates an authentication issue.
- * @param message The error message to check.
- * @returns True if the message indicates an auth error.
- */
-const isAuthErrorMessage = (message: string): boolean =>
-    message.includes("requires you to be logged in")
-    || message.includes("authentication")
-    || message.includes("Unauthorized")
-    || AUTH_STATUS_401.test(message)
-    || AUTH_STATUS_403.test(message);
-
-/**
- * Handle errors from publish dry-run command.
- * @param error The error to handle.
- * @param registry The registry URL.
- */
-const handlePublishError = (error: unknown, registry: string): never => {
-    // If it's already an AggregateError, re-throw it
-    if (error instanceof AggregateError) {
-        throw error;
-    }
-
-    // Check stderr for auth errors (execa errors have stderr property)
-    // Handle both string and array formats
-    const errorStderrRaw = (error as { stderr?: string | string[] }).stderr;
-    const errorStderr = Array.isArray(errorStderrRaw) ? errorStderrRaw.join("\n") : errorStderrRaw ?? "";
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    const combinedMessage = `${errorStderr} ${errorMessage}`;
-
-    // Check for connection errors or timeouts (registry not available) - treat as auth error
-    if (isConnectionError(error)) {
-        const semanticError = getError("EINVALIDNPMAUTH", { registry });
-
-        throw new AggregateError([semanticError], semanticError.message);
-    }
-
-    // Check for authentication errors
-    if (isAuthErrorMessage(combinedMessage)) {
-        const semanticError = getError("EINVALIDNPMAUTH", { registry });
-
-        throw new AggregateError([semanticError], semanticError.message);
-    }
-
-    // Re-throw other errors
-    throw error;
-};
-
-/**
- * Verify authentication for custom registries using dry-run publish.
+ * Verify authentication for custom registries using pnpm whoami.
+ * Results are cached per registry/auth token combination to prevent throttling in monorepos.
  * @param npmrc Path to the .npmrc file.
  * @param registry The registry URL.
  * @param context The semantic-release context.
- * @param pkgRoot Optional package root directory for dry-run publishing.
  */
-const verifyAuthContextAgainstCustomRegistry = async (npmrc: string, registry: string, context: CommonContext, pkgRoot = "."): Promise<void> => {
-    const { cwd, env, logger, stderr, stdout } = context;
+const verifyAuthContextAgainstCustomRegistry = async (npmrc: string, registry: string, context: CommonContext): Promise<void> => {
+    const cacheKey = getCacheKey(registry, context);
+
+    // Check cache first to avoid redundant whoami calls
+    if (whoamiCache.has(cacheKey)) {
+        debug(`Using cached whoami result for registry "${registry}"`);
+
+        const cachedResult = whoamiCache.get(cacheKey);
+
+        try {
+            await cachedResult;
+
+            return;
+        } catch {
+            debug(`Cached whoami result failed, retrying for registry "${registry}"`);
+
+            whoamiCache.delete(cacheKey);
+        }
+    }
+
+    const verificationPromise = (async (): Promise<void> => {
+        const { cwd, env, logger, stderr, stdout } = context;
+
+        try {
+            logger.log(`Running "pnpm whoami" to verify authentication on registry "${registry}"`);
+
+            const whoamiResult = await execa("pnpm", ["whoami", "--registry", registry], {
+                cwd,
+                env: {
+                    ...env,
+                    NPM_CONFIG_USERCONFIG: npmrc,
+                },
+                preferLocal: true,
+                timeout: 5000, // 5 second timeout to prevent hanging when registry is unavailable
+            });
+
+            if (whoamiResult.stdout) {
+                stdout.write(whoamiResult.stdout);
+            }
+
+            if (whoamiResult.stderr) {
+                stderr.write(whoamiResult.stderr);
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            if (isConnectionError(error)) {
+                const semanticError = getError("EINVALIDNPMAUTH", { registry });
+
+                throw new AggregateError([semanticError], semanticError.message, { cause: error });
+            }
+
+            const semanticError = getError("EINVALIDNPMTOKEN", { registry });
+
+            throw new AggregateError([semanticError], semanticError.message, { cause: error });
+        }
+    })();
+
+    whoamiCache.set(cacheKey, verificationPromise);
 
     try {
-        logger.log(`Running "pnpm publish --dry-run" to verify authentication on registry "${registry}"`);
-
-        const publishArgs = ["publish", pkgRoot, "--dry-run", "--tag=semantic-release-auth-check", "--registry", registry, "--no-git-checks"];
-        const publishOptions = {
-            cwd,
-            env: {
-                ...env,
-                NPM_CONFIG_USERCONFIG: npmrc,
-            },
-            preferLocal: true,
-            timeout: 5000, // 5 second timeout to prevent hanging when registry is unavailable
-        };
-
-        const publishResult = await execa("pnpm", publishArgs, publishOptions);
-
-        // Log the output (stdout/stderr are strings when lines option is not used)
-        const stdoutString = Array.isArray(publishResult.stdout) ? publishResult.stdout.join("\n") : publishResult.stdout || "";
-        const stderrString = Array.isArray(publishResult.stderr) ? publishResult.stderr.join("\n") : publishResult.stderr || "";
-
-        if (stdoutString) {
-            stdout.write(stdoutString);
-        }
-
-        if (stderrString) {
-            stderr.write(stderrString);
-        }
+        await verificationPromise;
     } catch (error) {
-        handlePublishError(error, registry);
+        if (isConnectionError(error)) {
+            whoamiCache.delete(cacheKey);
+        }
+
+        throw error;
     }
 };
 
@@ -284,19 +268,17 @@ const verifyAuthContextAgainstCustomRegistry = async (npmrc: string, registry: s
  * The helper first checks if an OIDC context is established for trusted publishing.
  * If OIDC is available and the registry is the official npm registry, it skips further authentication.
  * Otherwise, it ensures that `npmrc` contains valid authentication data by delegating to
- * {@link setNpmrcAuth}. For the official registry, it runs `pnpm whoami` to perform an online
- * verification of the credentials. For custom registries, it performs a dry-run publish to check authentication.
+ * {@link setNpmrcAuth}. It then runs `pnpm whoami` to perform an online verification of the
+ * credentials against the target registry (official or custom).
  * @param npmrc – Path to the `.npmrc` that contains (or will receive) credentials.
  * @param package_ – The package manifest (used to derive the registry when `publishConfig.registry` is set).
  * @param context – semantic-release context providing env, logger, streams, etc.
- * @param pkgRoot – Optional package root directory for dry-run publishing.
  * @returns Resolves when authentication has been verified.
  */
-const verifyAuth: (npmrc: string, package_: PackageJson, context: CommonContext, pkgRoot?: string) => Promise<void> = async (
+const verifyAuth: (npmrc: string, package_: PackageJson, context: CommonContext) => Promise<void> = async (
     npmrc: string,
     package_: PackageJson,
     context: CommonContext,
-    pkgRoot?: string,
 ): Promise<void> => {
     const registry = getRegistry(package_, context);
 
@@ -339,11 +321,10 @@ const verifyAuth: (npmrc: string, package_: PackageJson, context: CommonContext,
     const normalizedRegistry = normalizeUrl(registry);
     const normalizedOfficialRegistry = normalizeUrl(OFFICIAL_REGISTRY);
 
-    // Verify authentication based on registry type
-    // Use whoami only for the official npm registry, use dry-run publish for all other registries
+    // Verify authentication using pnpm whoami for both official and custom registries
     await (normalizedRegistry === normalizedOfficialRegistry
         ? verifyAuthContextAgainstRegistry(npmrc, registry, context)
-        : verifyAuthContextAgainstCustomRegistry(npmrc, registry, context, pkgRoot));
+        : verifyAuthContextAgainstCustomRegistry(npmrc, registry, context));
 };
 
 export default verifyAuth;

--- a/packages/semantic-release-pnpm/src/verify/verify-auth.ts
+++ b/packages/semantic-release-pnpm/src/verify/verify-auth.ts
@@ -186,83 +186,6 @@ const verifyAuthContextAgainstRegistry = async (npmrc: string, registry: string,
 };
 
 /**
- * Verify authentication for custom registries using pnpm whoami.
- * Results are cached per registry/auth token combination to prevent throttling in monorepos.
- * @param npmrc Path to the .npmrc file.
- * @param registry The registry URL.
- * @param context The semantic-release context.
- */
-const verifyAuthContextAgainstCustomRegistry = async (npmrc: string, registry: string, context: CommonContext): Promise<void> => {
-    const cacheKey = getCacheKey(registry, context);
-
-    // Check cache first to avoid redundant whoami calls
-    if (whoamiCache.has(cacheKey)) {
-        debug(`Using cached whoami result for registry "${registry}"`);
-
-        const cachedResult = whoamiCache.get(cacheKey);
-
-        try {
-            await cachedResult;
-
-            return;
-        } catch {
-            debug(`Cached whoami result failed, retrying for registry "${registry}"`);
-
-            whoamiCache.delete(cacheKey);
-        }
-    }
-
-    const verificationPromise = (async (): Promise<void> => {
-        const { cwd, env, logger, stderr, stdout } = context;
-
-        try {
-            logger.log(`Running "pnpm whoami" to verify authentication on registry "${registry}"`);
-
-            const whoamiResult = await execa("pnpm", ["whoami", "--registry", registry], {
-                cwd,
-                env: {
-                    ...env,
-                    NPM_CONFIG_USERCONFIG: npmrc,
-                },
-                preferLocal: true,
-                timeout: 5000, // 5 second timeout to prevent hanging when registry is unavailable
-            });
-
-            if (whoamiResult.stdout) {
-                stdout.write(whoamiResult.stdout);
-            }
-
-            if (whoamiResult.stderr) {
-                stderr.write(whoamiResult.stderr);
-            }
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            if (isConnectionError(error)) {
-                const semanticError = getError("EINVALIDNPMAUTH", { registry });
-
-                throw new AggregateError([semanticError], semanticError.message, { cause: error });
-            }
-
-            const semanticError = getError("EINVALIDNPMTOKEN", { registry });
-
-            throw new AggregateError([semanticError], semanticError.message, { cause: error });
-        }
-    })();
-
-    whoamiCache.set(cacheKey, verificationPromise);
-
-    try {
-        await verificationPromise;
-    } catch (error) {
-        if (isConnectionError(error)) {
-            whoamiCache.delete(cacheKey);
-        }
-
-        throw error;
-    }
-};
-
-/**
  * Verify that the provided npm credentials grant access to the target registry.
  *
  * The helper first checks if an OIDC context is established for trusted publishing.
@@ -318,13 +241,7 @@ const verifyAuth: (npmrc: string, package_: PackageJson, context: CommonContext)
 
     await setNpmrcAuth(npmrc, registry, context);
 
-    const normalizedRegistry = normalizeUrl(registry);
-    const normalizedOfficialRegistry = normalizeUrl(OFFICIAL_REGISTRY);
-
-    // Verify authentication using pnpm whoami for both official and custom registries
-    await (normalizedRegistry === normalizedOfficialRegistry
-        ? verifyAuthContextAgainstRegistry(npmrc, registry, context)
-        : verifyAuthContextAgainstCustomRegistry(npmrc, registry, context));
+    await verifyAuthContextAgainstRegistry(npmrc, registry, context);
 };
 
 export default verifyAuth;


### PR DESCRIPTION
## Problem

`verifyAuthContextAgainstCustomRegistry` uses `pnpm publish --dry-run` to verify authentication against custom registries (GitLab Package Registry, GitHub Packages, Verdaccio, Artifactory, etc.).

This approach breaks as soon as **the package version already exists** in the registry. In that case the registry responds with:

```
npm error You cannot publish over the previously published versions: X.Y.Z.
```

This is **not an auth error** — it means the request was authenticated and processed by the registry. However, since `handlePublishError` only recognises connection errors and 401/403/Unauthorized patterns, the error propagates as an unhandled exception and causes the entire `verifyConditions` phase to abort, blocking the release pipeline for **all packages** in a monorepo.

## Fix

Replace `pnpm publish --dry-run` with `pnpm whoami --registry <registry>` for custom registries, mirroring what already happens for the official npm registry via `verifyAuthContextAgainstRegistry`.

`pnpm whoami` is part of the standard npm registry API and is supported by all major npm-compatible registries (GitLab, GitHub Packages, Verdaccio, Artifactory, Nexus). It gives:
- **Valid credentials** → exits 0, prints the username
- **Invalid/missing credentials** → exits 1 with a clear 401/Unauthorized error
- No dependency on whether a specific package version exists

### Additional improvements
- The custom registry path now benefits from the same **whoami caching** already in place for the official registry, avoiding redundant network calls in monorepos with many packages.
- Removed `handlePublishError` (was only used by the dry-run path) and the now-unused `pkgRoot` parameter from `verifyAuth`.

## Changed files

| File | Change |
|------|--------|
| `src/verify/verify-auth.ts` | Replace `verifyAuthContextAgainstCustomRegistry` implementation; remove `handlePublishError`; remove `pkgRoot` param from `verifyAuth` |
| `src/verify/index.ts` | Remove `pluginConfig.pkgRoot` argument from `verifyAuth` call |
| `__tests__/unit/verify/verify-auth.test.ts` | Update tests to reflect whoami behaviour; add regression test for "already published" scenario |

## Reproducer

Any monorepo using `@anolilab/semantic-release-pnpm` with a custom registry where at least one package has already been published once. The very first CI run after publishing version `X.Y.Z` will fail on `verifyConditions` with a misleading TypeError or unhandled error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified authentication to always verify registry identity with a non-publishing check, removing flaky dry-run publish probes and improving detection of invalid npm tokens.

* **Tests**
  * Updated unit tests and assertions to match the new verification flow and revised error messages/behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->