### PR TITLE
fix: restore commit groups in generated changelogs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,13 @@
 {
     extends: ["github>anolilab/renovate-config"],
+    packageRules: [
+        {
+            // conventional-changelog-conventionalcommits v10 renders through
+            // conventional-changelog-writer v9 function templates. @semantic-release/
+            // release-notes-generator still bundles writer v8, which drops every commit
+            // group and emits a heading-only changelog. Stay on v9 until it ships writer v9.
+            matchPackageNames: ["conventional-changelog-conventionalcommits"],
+            allowedVersions: "<10",
+        },
+    ],
 }

--- a/packages/multi-semantic-release/.releaserc.json
+++ b/packages/multi-semantic-release/.releaserc.json
@@ -50,7 +50,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         [

--- a/packages/multi-semantic-release/__tests__/release-notes-preset-compat.test.ts
+++ b/packages/multi-semantic-release/__tests__/release-notes-preset-compat.test.ts
@@ -1,0 +1,35 @@
+import { generateNotes } from "@semantic-release/release-notes-generator";
+import { describe, expect, it } from "vitest";
+
+/**
+ * conventional-changelog-conventionalcommits v10 renders through the function templates of
+ * conventional-changelog-writer v9. @semantic-release/release-notes-generator still bundles
+ * writer v8, which silently drops every commit group and emits a heading-only changelog.
+ * This guards the pairing: a preset bump that outruns the writer fails here instead of
+ * shipping empty release notes.
+ */
+describe("release notes preset compatibility", () => {
+    it("renders commit groups for the conventionalcommits preset", async () => {
+        expect.assertions(3);
+
+        const commits = [
+            { hash: "a".repeat(40), message: "feat(core): add a thing" },
+            { hash: "b".repeat(40), message: "fix(core): stop breaking a thing" },
+        ];
+
+        const notes = await generateNotes(
+            { preset: "conventionalcommits" },
+            {
+                commits,
+                cwd: process.cwd(),
+                lastRelease: { gitTag: "v1.0.0", version: "1.0.0" },
+                nextRelease: { gitTag: "v1.1.0", version: "1.1.0" },
+                options: { repositoryUrl: "https://github.com/anolilab/semantic-release" },
+            },
+        );
+
+        expect(notes).toContain("### Features");
+        expect(notes).toContain("add a thing");
+        expect(notes).toContain("stop breaking a thing");
+    });
+});

--- a/packages/rc/.releaserc.json
+++ b/packages/rc/.releaserc.json
@@ -50,7 +50,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         [

--- a/packages/semantic-release-clean-package-json/.releaserc.json
+++ b/packages/semantic-release-clean-package-json/.releaserc.json
@@ -55,7 +55,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         [

--- a/packages/semantic-release-pnpm/.releaserc.json
+++ b/packages/semantic-release-pnpm/.releaserc.json
@@ -55,7 +55,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         [

--- a/packages/semantic-release-preset/.releaserc.json
+++ b/packages/semantic-release-preset/.releaserc.json
@@ -50,7 +50,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         [

--- a/packages/semantic-release-preset/README.md
+++ b/packages/semantic-release-preset/README.md
@@ -157,7 +157,7 @@ Without npm release:
         [
             "@semantic-release/git",
             {
-                message: "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}",
+                message: "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}",
             },
         ],
         [

--- a/packages/semantic-release-preset/config/with-npm.json
+++ b/packages/semantic-release-preset/config/with-npm.json
@@ -57,7 +57,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ]
     ]

--- a/packages/semantic-release-preset/config/with-pnpm.json
+++ b/packages/semantic-release-preset/config/with-pnpm.json
@@ -50,7 +50,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         [

--- a/packages/semantic-release-preset/config/with-yarn.json
+++ b/packages/semantic-release-preset/config/with-yarn.json
@@ -50,7 +50,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         [

--- a/packages/semantic-release-preset/config/without-npm.json
+++ b/packages/semantic-release-preset/config/without-npm.json
@@ -55,7 +55,7 @@
         [
             "@semantic-release/git",
             {
-                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\\n\\n${nextRelease.notes}"
+                "message": "chore(release): ${nextRelease.gitTag} [skip ci]\n\n${nextRelease.notes}"
             }
         ]
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ catalogs:
       specifier: 4.0.2
       version: 4.0.2
     conventional-changelog-conventionalcommits:
-      specifier: 10.2.1
-      version: 10.2.1
+      specifier: 9.3.1
+      version: 9.3.1
     dockerode:
       specifier: 5.0.1
       version: 5.0.1
@@ -190,8 +190,8 @@ catalogs:
       specifier: ^7.1.0
       version: 7.1.0
     conventional-changelog-conventionalcommits:
-      specifier: 10.2.1
-      version: 10.2.1
+      specifier: 9.3.1
+      version: 9.3.1
     debug:
       specifier: ^4.4.3
       version: 4.4.3
@@ -594,7 +594,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       conventional-changelog-conventionalcommits:
         specifier: catalog:dev
-        version: 10.2.1
+        version: 9.3.1
       cross-env:
         specifier: catalog:node
         version: 10.1.0
@@ -700,7 +700,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       conventional-changelog-conventionalcommits:
         specifier: catalog:dev
-        version: 10.2.1
+        version: 9.3.1
       cross-env:
         specifier: catalog:node
         version: 10.1.0
@@ -939,7 +939,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       conventional-changelog-conventionalcommits:
         specifier: catalog:dev
-        version: 10.2.1
+        version: 9.3.1
       cross-env:
         specifier: catalog:node
         version: 10.1.0
@@ -1014,7 +1014,7 @@ importers:
         version: 14.1.1(semantic-release@25.0.9(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)
       conventional-changelog-conventionalcommits:
         specifier: catalog:prod
-        version: 10.2.1
+        version: 9.3.1
       semantic-release-yarn:
         specifier: catalog:cli
         version: 3.0.2(semantic-release@25.0.9(supports-color@10.2.2)(typescript@6.0.3))(typescript@6.0.3)
@@ -4650,6 +4650,10 @@ packages:
   conventional-changelog-conventionalcommits@10.2.1:
     resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
     engines: {node: '>=22'}
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
     resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
@@ -13154,6 +13158,10 @@ snapshots:
   conventional-changelog-conventionalcommits@10.2.1:
     dependencies:
       '@conventional-changelog/template': 1.2.1
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    dependencies:
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalogs:
     '@ckeditor/typedoc-plugins': 59.0.0
     '@visulima/packem': 2.0.0-alpha.99
     '@visulima/pail': 4.0.2
-    conventional-changelog-conventionalcommits: 10.2.1
+    conventional-changelog-conventionalcommits: 9.3.1
     dockerode: 5.0.1
     file-url: ^4.0.0
     get-stream: 9.0.1
@@ -92,7 +92,7 @@ catalogs:
     '@visulima/package': 5.0.11
     audit-ci: ^7.1.0
     blork: ^9.3.0
-    conventional-changelog-conventionalcommits: 10.2.1
+    conventional-changelog-conventionalcommits: 9.3.1
     debug: ^4.4.3
     detect-indent: ^7.0.2
     detect-newline: ^4.0.1


### PR DESCRIPTION
## The defect

`conventional-changelog-conventionalcommits` v10 renders through the function-template API of `conventional-changelog-writer` v9. `@semantic-release/release-notes-generator@14.1.1` (still the latest) pins writer `^8`, which calls the preset's `transform` but never renders the resulting commit groups.

Result: every generated changelog entry collapsed to a bare version heading. Version bumps stayed correct throughout, because the analyzer uses `whatBump`, which is unaffected — only the notes were lost, which is why this went unnoticed.

The catalog moved `9.3.1 → 10.2.1` on 2026-07-23. `@anolilab/multi-semantic-release` 4.4.5 (2026-06-20) is the last release with real notes; 4.4.6 (2026-07-23) onward are empty.

Reproduced with writer 8.4.0 and the same two commits:

| preset | output |
| --- | --- |
| 9.3.1 | heading + `### Features` + `### Bug Fixes` |
| 10.3.0 | heading only |

## The fix

- Pin both catalogs to `9.3.1`.
- Block v10 in renovate until the notes generator ships writer v9.
- Add `release-notes-preset-compat.test.ts`, which renders two commits through the preset and asserts the groups appear — the next bump fails there instead of silently emptying the changelog.

## Second, unrelated defect

The git plugin message used `"\\n\\n"` inside JSON — an escaped backslash followed by `n`, not a line break. Every release commit was written as a single line with the whole release notes appended to the subject, so the notes never became a commit body:

```
chore(release): @anolilab/multi-semantic-release@4.4.7 [skip ci]\n\n## @anolilab/multi-semantic-release [4.4.7](...) (2026-08-10)
```

Corrected to `"\n\n"` in the four shipped configs, the README example, and the package-local overrides that copied the same string.

## Follow-up (not in this PR)

`chore` is `hidden: false` in the preset, so `chore(release):` commits show up in the next changelog under "Miscellaneous Chores". Pre-existing; happy to filter those separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111EdBwxAMbkE16gv9d9PiT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated release commit formatting so release tags, skip-CI markers, and release notes appear on separate lines with proper spacing.
  * Improved compatibility for conventional commit release-note generation, including clear feature and fix sections.

* **Documentation**
  * Updated configuration guidance to reflect the corrected release message formatting.

* **Chores**
  * Added safeguards to maintain consistent release-note output across supported release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->