### PR TITLE
fix(ci): keep pnpm warnings out of the preview release JSON

### DIFF
--- a/scripts/publish-preview-release.js
+++ b/scripts/publish-preview-release.js
@@ -13,7 +13,12 @@ if (!env.CHANGED_FILES) {
     exit(0);
 }
 
-const json = execSync(`pnpm exec nx show projects --affected --exclude=*-bench,docs,storybook --files=${process.env.CHANGED_FILES} --json`).toString("utf8");
+// `--silent` keeps pnpm's own output off stdout. The build step ahead of this script rewrites the
+// `typesVersions` field of the built package.json files, after which every pnpm invocation prints
+// "[WARN] Your node_modules are out of sync with your lockfile" in front of the JSON below.
+const json = execSync(`pnpm --silent exec nx show projects --affected --exclude=*-bench,docs,storybook --files=${process.env.CHANGED_FILES} --json`).toString(
+    "utf8",
+);
 
 /** @type {Array<{ path: string, private: boolean, peerDependencies?: Record<string, string> }>} */
 const affectedRepoPackages = JSON.parse(json);


### PR DESCRIPTION
The **Preview Release** job has been failing on every pull request that touches a package — #402's branch, the renovate branches, and all three of #403/#404/#405:

```
[WARN] Your node_modules are out of sync with your lockfile. The lockfile in
/home/runner/work/semantic-release/semantic-release does not satisfy project of id packages/rc
 ^
SyntaxError: Unexpected token 'W', "[WARN] Your"... is not valid JSON
    at JSON.parse (<anonymous>)
    at .../scripts/publish-preview-release.js:19:35
```

## Cause

The job's Build step runs `build:affected:packages:prod`, and packem's node10-compatibility plugin rewrites the `typesVersions` field of the built `package.json` files ("Your package.json 'typesVersions' field has been updated"). From that point the workspace manifests no longer match the install, so **every** pnpm invocation prints the out-of-sync warning — on stdout, not stderr.

The next step is `node ./scripts/publish-preview-release.js`, which does `JSON.parse` on the stdout of `pnpm exec nx show projects … --json`. The warning lands in front of the JSON and the parse dies, failing the job.

## Fix

`pnpm --silent exec` — the silent reporter keeps pnpm's own output off stdout and leaves nx's JSON as the only thing printed.

Reproduced locally by putting a workspace manifest out of sync with the lockfile:

```
$ pnpm exec nx show projects … --json
[WARN] Your node_modules are out of sync with your lockfile. The workspace structure has changed since last install
["semantic-release-pnpm", …]

$ pnpm --silent exec nx show projects … --json
["semantic-release-pnpm", …]
```

With the same drift in place, `CHANGED_FILES=… node ./scripts/publish-preview-release.js` now gets through the parse and on to the publish step (which only fails locally because `pkg-pr-new` requires GitHub Actions).

This leaves the build's manifest rewriting alone — it is packem doing its job — and just stops the script from choking on the warning it causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqVjBDe8SkgMK7LpDpgjJ7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced console output during preview release publishing.
  * Preserved existing project selection and publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->