### PR TITLE
fix(ci): unbreak eslint and the multi-semantic-release git fixtures

### DIFF
--- a/packages/multi-semantic-release/__tests__/bin/cli.test.ts
+++ b/packages/multi-semantic-release/__tests__/bin/cli.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, it } from "vitest";
 import { copyDirectory } from "../helpers/file";
 import { gitCommitAll, gitInit, gitInitOrigin, gitPush } from "../helpers/git";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesPath = resolve(__dirname, "../../__fixtures__");
 const msrBin = resolve(__dirname, "../../dist/bin/cli.js");

--- a/packages/multi-semantic-release/__tests__/helpers/git.ts
+++ b/packages/multi-semantic-release/__tests__/helpers/git.ts
@@ -11,6 +11,15 @@ import { temporaryDirectory } from "tempy";
 
 import { validate } from "../../src/utils/validate";
 
+// Git exports these to its hooks, pointing at the repository the hook runs for, and they take
+// precedence over the `cwd` of every git call below — and of the semantic-release runs the tests
+// spawn. Run the suite from a hook (the `lint-staged` `vitest related`, say) without dropping them
+// and the fixtures operate on the repository being committed to, rewriting its index.
+for (const variable of ["GIT_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_WORK_TREE"]) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete process.env[variable];
+}
+
 /**
  * Add a Git config setting.
  * @param cwd The CWD of the Git repository.
@@ -56,8 +65,11 @@ export const gitInit = (branch: string = "master"): string => {
     execaSync("git", ["init"], { cwd });
     execaSync("git", ["checkout", "-b", branch], { cwd });
 
-    // Disable GPG signing for commits.
+    // Disable GPG signing for commits and tags. A signed tag needs a message, which the plain
+    // `git tag <name> <sha>` semantic-release runs does not pass, so `tag.gpgsign = true` in the
+    // developer's global config would fail every release in these fixtures.
     gitConfig(cwd, "commit.gpgsign", false);
+    gitConfig(cwd, "tag.gpgsign", false);
     gitUser(cwd);
 
     // Return directory.
@@ -72,7 +84,10 @@ export const gitInitRemote = (): string => {
     // Init bare Git repository in a temp directory.
     const cwd = temporaryDirectory();
 
-    execaSync("git", ["init", "--bare"], { cwd });
+    // The branch has to match the one `gitInit` creates: semantic-release fetches the remote HEAD,
+    // which fails on a remote whose HEAD points at a branch that was never pushed — as it does for
+    // everyone whose `init.defaultBranch` is not `master`.
+    execaSync("git", ["init", "--bare", "--initial-branch=master"], { cwd });
 
     // Turn remote path into a file URL.
     // Return URL for remote.

--- a/packages/multi-semantic-release/__tests__/release-notes-preset-compat.test.ts
+++ b/packages/multi-semantic-release/__tests__/release-notes-preset-compat.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 /**
  * conventional-changelog-conventionalcommits v10 renders through the function templates of
- * conventional-changelog-writer v9. @semantic-release/release-notes-generator still bundles
+ * conventional-changelog-writer v9. `@semantic-release/release-notes-generator` still bundles
  * writer v8, which silently drops every commit group and emits a heading-only changelog.
  * This guards the pairing: a preset bump that outruns the writer fails here instead of
  * shipping empty release notes.

--- a/packages/multi-semantic-release/src/types/semantic-release.d.ts
+++ b/packages/multi-semantic-release/src/types/semantic-release.d.ts
@@ -16,3 +16,7 @@ declare module "semantic-release/lib/get-config.js" {
         options: Options,
     ): Promise<{ options: Record<string, unknown>; plugins: Record<string, unknown> }>;
 }
+
+declare module "@semantic-release/release-notes-generator" {
+    export function generateNotes(pluginConfig: Record<string, unknown>, context: Record<string, unknown>): Promise<string>;
+}

--- a/packages/rc/__tests__/rc-unmocked.test.ts
+++ b/packages/rc/__tests__/rc-unmocked.test.ts
@@ -11,7 +11,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { rc } from "../src";
 
 const mocks = vi.hoisted(() => {
-    // eslint-disable-next-line vitest/require-mock-type-parameters
     return { mockedCwd: vi.fn(), mockedFindUpSync: vi.fn(), mockedHomeDir: vi.fn(), mockedIsAccessibleSync: vi.fn(), mockedReadFileSync: vi.fn() };
 });
 

--- a/packages/rc/__tests__/rc.test.ts
+++ b/packages/rc/__tests__/rc.test.ts
@@ -24,7 +24,6 @@ const addExtensions = (sources: string[][]) =>
     }, []);
 
 const mocks = vi.hoisted(() => {
-    // eslint-disable-next-line vitest/require-mock-type-parameters
     return { mockedCwd: vi.fn(), mockedHomeDir: vi.fn(), mockedIsAccessibleSync: vi.fn(), mockedReadFileSync: vi.fn() };
 });
 

--- a/packages/semantic-release-clean-package-json/__tests__/index.test.ts
+++ b/packages/semantic-release-clean-package-json/__tests__/index.test.ts
@@ -38,11 +38,8 @@ const context: Partial<PublishContext> = {
         version: "1.0.0",
     },
     logger: {
-        // eslint-disable-next-line vitest/require-mock-type-parameters
         error: vi.fn(),
-        // eslint-disable-next-line vitest/require-mock-type-parameters
         log: vi.fn(),
-        // eslint-disable-next-line vitest/require-mock-type-parameters
         success: vi.fn(),
     },
     nextRelease: {


### PR DESCRIPTION
Two independent breakages found while chasing the red pipelines on #403/#404/#405. Both are on `main` today, neither comes from those branches.

## 1. `lint:eslint` fails on a clean checkout (commit 2)

`pnpm run lint:eslint` reports nine errors on plain `main`, so the **Lint (eslint, types, attw)** job is red on every pull request:

- six `eslint-disable` comments no longer match a reported problem — `vitest/require-mock-type-parameters` in `rc.test.ts`, `rc-unmocked.test.ts` and `semantic-release-clean-package-json/__tests__/index.test.ts`, `@typescript-eslint/naming-convention` in `bin/cli.test.ts`. With `reportUnusedDisableDirectives` those are errors. Deleted.
- `release-notes-preset-compat.test.ts` calls `generateNotes` from `@semantic-release/release-notes-generator`, which ships no type declarations, so the call and its result are typed as `error` and trip `no-unsafe-call`/`no-unsafe-assignment`. Declared the module next to the other untyped semantic-release modules in `src/types/semantic-release.d.ts`.
- the same file's JSDoc names the package unquoted, which reads as an inline tag (`jsdoc/escape-inline-tags`). Quoted.

After this, `pnpm run lint:eslint` and `pnpm run lint:types` both pass repo-wide.

## 2. The git fixtures inherit the developer's git setup (commit 1)

25 of `multi-semantic-release`'s integration tests fail locally on a machine configured the way most are today. Three separate causes, all in `__tests__/helpers/git.ts`:

**`GIT_DIR` and friends.** Git exports `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY` and `GIT_WORK_TREE` to its hooks, and they take precedence over `cwd` — for the helper's own calls *and* for the semantic-release runs the tests spawn. Run the suite from a hook, which the repo's own `lint-staged` config does (`vitest related` on a changed test file), and the fixtures operate on the repository being committed to.

This is not theoretical: it happened to me while preparing this branch. The pre-commit hook ran these tests, a fixture's `git add`/`git commit` went to the real index, and the commit that came out deleted 389 files — the whole repository — because the tree it committed was a fixture's. I reset it; nothing was pushed. The helper now drops those variables at import.

Verified both ways, with `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` pointed at a scratch repo:

```
before: 2 failed (2)   after: 2 passed (2)   scratch index: unchanged
```

and the commit of this very change went through the real pre-commit hook without disturbing the index.

**The remote's default branch.** `gitInitRemote` runs `git init --bare`, so the remote's HEAD follows the developer's `init.defaultBranch`. For anyone not on `master` that HEAD names a branch which is never pushed, and semantic-release dies with `git fetch --tags` → "couldn't find remote ref HEAD". Now created with `--initial-branch=master`, matching what `gitInit` makes.

**Tag signing.** `tag.gpgsign = true` in a global config turns the plain `git tag <name> <sha>` semantic-release runs into a signed tag, which needs a message it does not pass: "fatal: no tag message?". The helper already disabled `commit.gpgsign`; it now disables `tag.gpgsign` too.

With all three, `multi-semantic-release.test.ts` and `bin/cli.test.ts` go from 25 failures to 29/29 passing locally.

## Not fixed here

- `bin/cli.test.ts` runs right at the 5 s per-test timeout on a loaded machine and times out intermittently; it passes on its own. Worth a longer `testTimeout`, but that is a separate call.
- `prettier --check` fails on three files in `semantic-release-pnpm` that nothing here touches. CI does not run prettier, so it is not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqVjBDe8SkgMK7LpDpgjJ7
