### PR TITLE
ci: sync pnpm-lock.yaml with the manifests the release just bumped

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,6 +11,14 @@ on: # yamllint disable-line rule:truthy
             - "next-major"
             - "alpha"
             - "beta"
+    workflow_dispatch: # yamllint disable-line rule:empty-values
+
+# A release run must never be cancelled mid-flight: multi-semantic-release pushes a tag and a
+# per-tag channel note for every package, and a run cancelled between those two pushes leaves a
+# tag whose note is missing. Queue release runs instead of replacing them.
+concurrency:
+    group: "${{ github.workflow }}-${{ github.ref }}"
+    cancel-in-progress: false
 
 permissions:
     contents: "read" # for checkout
@@ -90,3 +98,27 @@ jobs:
                   GIT_COMMITTER_NAME: "github-actions-shell"
                   GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
               run: "node packages/multi-semantic-release/dist/bin/cli.js"
+
+            # multi-semantic-release pushes per-package `chore(release)` commits that bump each
+            # package.json (and any cross-package dependency ranges), but @semantic-release/git only
+            # stages per-package assets — pnpm-lock.yaml lives at the root and drifts. Until the
+            # scheduled lock file maintenance run catches up, every frozen-lockfile install on main
+            # and on every open pull request fails with ERR_PNPM_OUTDATED_LOCKFILE. Refresh here.
+            - name: "Refresh pnpm-lock.yaml against released manifests"
+              if: "success()"
+              shell: "bash"
+              # --no-frozen-lockfile is intentional: this step exists to regenerate the lockfile
+              # after the release bumped versions. --ignore-scripts keeps any postinstall from
+              # running with the release token in env — --lockfile-only installs nothing anyway,
+              # but belt-and-suspenders.
+              run: "pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts"
+
+            - name: "Commit refreshed lockfile"
+              if: "success()"
+              uses: "stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d" # v7.2.0
+              with:
+                  file_pattern: "pnpm-lock.yaml"
+                  commit_message: "chore(deps): sync pnpm-lock.yaml with released manifests [skip ci]"
+                  commit_user_name: "github-actions-shell"
+                  commit_user_email: "github-actions[bot]@users.noreply.github.com"
+                  commit_author: "github-actions-shell <github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
Ports the release-time lockfile sync that `visulima/visulima` and `anolilab/lunora` already run. Both repos use this same multi-semantic-release tooling; this repo is the one that never got the step, which is why the lockfile race keeps biting here and not there.

## The race

multi-semantic-release commits a `chore(release)` per package, bumping that `package.json` and the cross-package ranges pointing at it. `@semantic-release/git` stages per-package assets only — `pnpm-lock.yaml` sits at the root and is left behind. Every frozen-lockfile install between that moment and the next scheduled **Lock File Maintenance** commit fails:

```
[ERR_PNPM_OUTDATED_LOCKFILE] … pnpm-lock.yaml is not up to date with <ROOT>/packages/semantic-release-pnpm/package.json
  - @anolilab/rc (lockfile: 4.0.6, manifest: 4.0.7)
```

That window is hours wide, and everything inside it is red: the release run for the next push to main, plus the Test and Lint jobs of every open pull request. In the last day it broke #403, #404, #405 and #396 — and it ate a release: the #375 fix merged at 08:25, its release run died on install, `@anolilab/semantic-release-pnpm` is still published as 8.1.20 without the fix, and `a57215f` (the maintenance commit that fixed the lockfile at 09:32) carries `[ci skip]`, so nothing re-triggered the release.

## What the sibling repos do

Both `visulima/visulima` and `anolilab/lunora` end their release job with, verbatim in intent:

```yaml
- name: "Refresh pnpm-lock.yaml against released manifests"
  run: "pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts"

- name: "Commit refreshed lockfile"
  uses: "stefanzweifel/git-auto-commit-action@…"
  with:
      file_pattern: "pnpm-lock.yaml"
      commit_message: "chore(deps): sync pnpm-lock.yaml with released manifests [skip ci]"
```

This PR adds exactly that, pinned to v7.2.0 of the action (the newer of the two SHAs the siblings use).

## Two smaller things they have and we do not

- **`workflow_dispatch`** — both siblings have it. Without it a release that failed this way can only be retried by pushing a commit to main, because re-running the failed run replays the old SHA with the stale lockfile. This is the button that would publish the pending #375 fix right now.
- **`concurrency` with `cancel-in-progress: false`** — lunora's comment explains why: a run cancelled between pushing a tag and pushing that tag's channel note leaves a tag no later run can map to a channel, and the next run then recomputes an existing version and dies on `git tag`. This repo currently sets no concurrency at all. visulima uses `cancel-in-progress: true`; I followed lunora, since the failure it describes is the more expensive one.

## Not ported

Other differences that look deliberate rather than missing: lunora's `environment: release` secret gating and `git config core.hooksPath /dev/null` before the release commits, and visulima's replacement of `lewagon/wait-on-check-action` with a `gh api` polling loop (they hit a macOS bundler problem this repo does not have). Happy to follow up on any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqVjBDe8SkgMK7LpDpgjJ7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the ability to manually start release workflows.
  * Improved release-run handling by queuing concurrent runs.
  * Automatically refreshes and commits the package lockfile after releases without triggering another CI run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->