### PR TITLE
fix(lint): type rc and clean-package-json instead of asserting past the checks

### DIFF
--- a/packages/rc/__tests__/rc-unmocked.test.ts
+++ b/packages/rc/__tests__/rc-unmocked.test.ts
@@ -1,49 +1,32 @@
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, realpathSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
-import { env } from "node:process";
+import { chdir, cwd, env } from "node:process";
 
 import { writeJsonSync } from "@visulima/fs";
 import { join } from "@visulima/path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { rc } from "../src";
-
-const mocks = vi.hoisted(() => {
-    return { mockedCwd: vi.fn(), mockedFindUpSync: vi.fn(), mockedHomeDir: vi.fn(), mockedIsAccessibleSync: vi.fn(), mockedReadFileSync: vi.fn() };
-});
-
-vi.mock(import("node:os"), async () => {
-    const actual = await vi.importActual("node:os");
-
-    return {
-        ...actual,
-        homedir: mocks.mockedHomeDir,
-    };
-});
-
-vi.mock(import("node:process"), async () => {
-    const actual = await vi.importActual("node:process");
-
-    return {
-        ...actual,
-        cwd: mocks.mockedCwd,
-    };
-});
 
 describe("rc-unmocked", () => {
     let cwdPath: string;
     let homePath: string;
+    let originalCwd: string;
 
     const npmEnvironment: Record<keyof typeof env, string | undefined> = {};
 
     beforeEach(() => {
-        cwdPath = mkdtempSync(pathJoin(tmpdir(), "rc-unmocked-"));
-        homePath = mkdtempSync(pathJoin(tmpdir(), "rc-unmocked-home-"));
+        originalCwd = cwd();
 
-        mocks.mockedCwd.mockReturnValue(cwdPath);
-        mocks.mockedHomeDir.mockReturnValue(homePath);
+        // realpathSync because the temp dir is reached through a symlink on macOS,
+        // and chdir reports the resolved path — the expected file lists are built
+        // from these values, so both sides have to agree.
+        const temporaryDirectory = tmpdir();
+
+        cwdPath = realpathSync(mkdtempSync(pathJoin(temporaryDirectory, "rc-unmocked-")));
+        homePath = realpathSync(mkdtempSync(pathJoin(temporaryDirectory, "rc-unmocked-home-")));
 
         // eslint-disable-next-line no-restricted-syntax
         for (const key in env) {
@@ -58,6 +41,8 @@ describe("rc-unmocked", () => {
     });
 
     afterEach(async () => {
+        chdir(originalCwd);
+
         // eslint-disable-next-line no-restricted-syntax,guard-for-in
         for (const key in npmEnvironment) {
             env[key] = npmEnvironment[key];
@@ -76,9 +61,11 @@ describe("rc-unmocked", () => {
             writeJsonSync(join(cwdPath, file), { test: index });
         });
 
-        mocks.mockedCwd.mockReturnValue(join(cwdPath, "grandparent", "parent", "cwd"));
+        // The default working directory is what is under test here, so move into it
+        // for real rather than replacing process.cwd with a stub.
+        chdir(join(cwdPath, "grandparent", "parent", "cwd"));
 
-        expect(rc("bem")).toStrictEqual({
+        expect(rc("bem", { home: homePath })).toStrictEqual({
             config: {
                 test: 0,
             },
@@ -98,6 +85,7 @@ describe("rc-unmocked", () => {
         expect(
             rc("bem", {
                 cwd: join(cwdPath, "grandparent", "parent", "cwd"),
+                home: homePath,
             }),
         ).toStrictEqual({
             config: {

--- a/packages/rc/__tests__/rc.test.ts
+++ b/packages/rc/__tests__/rc.test.ts
@@ -27,6 +27,12 @@ const mocks = vi.hoisted(() => {
     return { mockedCwd: vi.fn(), mockedHomeDir: vi.fn(), mockedIsAccessibleSync: vi.fn(), mockedReadFileSync: vi.fn() };
 });
 
+// The precedence rules under test span `/etc/bemrc`, `/.bemrc` and `$HOME`, and a
+// test process cannot create files at those paths. Faking the three modules that
+// reach the filesystem is the only way to exercise that ordering; the cases that
+// live entirely under a temp directory are covered without mocks in
+// rc-unmocked.test.ts.
+// eslint-disable-next-line no-restricted-syntax
 vi.mock(import("@visulima/fs"), async () => {
     const actual = await vi.importActual("@visulima/fs");
 
@@ -37,6 +43,7 @@ vi.mock(import("@visulima/fs"), async () => {
     };
 });
 
+// eslint-disable-next-line no-restricted-syntax -- see the note on the @visulima/fs mock above
 vi.mock(import("node:os"), async () => {
     const actual = await vi.importActual("node:os");
 
@@ -46,6 +53,7 @@ vi.mock(import("node:os"), async () => {
     };
 });
 
+// eslint-disable-next-line no-restricted-syntax -- see the note on the @visulima/fs mock above
 vi.mock(import("node:process"), async () => {
     const actual = await vi.importActual("node:process");
 

--- a/packages/rc/__tests__/utils/is-json.test.ts
+++ b/packages/rc/__tests__/utils/is-json.test.ts
@@ -6,7 +6,7 @@ describe(isJson, () => {
     it.each([5, "5", "true", "null", "{}", '{"foo": "bar"}', "[1, 2, 3]", '{"foo": "bar", "baz": "qux"}'])("should return true for valid JSON", (value) => {
         expect.assertions(1);
 
-        expect(isJson(value as string)).toBe(true);
+        expect(isJson(value)).toBe(true);
     });
 
     // eslint-disable-next-line no-void
@@ -15,7 +15,7 @@ describe(isJson, () => {
         (value) => {
             expect.assertions(1);
 
-            expect(isJson(value as string)).toBe(false);
+            expect(isJson(value)).toBe(false);
         },
     );
 });

--- a/packages/rc/src/index.ts
+++ b/packages/rc/src/index.ts
@@ -16,6 +16,23 @@ import { merge } from "ts-deepmerge";
 import isJson from "./utils/is-json";
 
 /**
+ * A single value in a configuration tree — whatever JSON, an ini file or an
+ * environment variable can express.
+ */
+type ConfigValue = boolean | null | number | ReadonlyArray<ConfigValue> | string | undefined | { [key: string]: ConfigValue };
+
+/** A configuration object keyed by name, nested to any depth. */
+type ConfigObject = { [key: string]: ConfigValue };
+
+/**
+ * Narrows a parsed value to an object we can merge. Written as a predicate rather
+ * than an assertion so the check that runs is the check the type rests on.
+ * @param value
+ * @returns
+ */
+const isConfigObject = (value: unknown): value is ConfigObject => typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
  * Modified copy of the env function from https://github.com/dominictarr/rc/blob/a97f6adcc37ee1cad06ab7dc9b0bd842bbc5c664/lib/utils.js#L42.
  * @license https://github.com/dominictarr/rc/blob/master/LICENSE.APACHE2
  * @license https://github.com/dominictarr/rc/blob/master/LICENSE.BSD
@@ -24,10 +41,8 @@ import isJson from "./utils/is-json";
  * @param environment
  * @returns
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getEnvironment = (prefix: string, environment: Record<string, string | undefined> = env): Record<string, any> => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const returnValue: Record<string, any> = {};
+const getEnvironment = (prefix: string, environment: Record<string, string | undefined> = env): ConfigObject => {
+    const returnValue: ConfigObject = {};
     const l = prefix.length;
 
     // eslint-disable-next-line no-restricted-syntax
@@ -46,13 +61,13 @@ const getEnvironment = (prefix: string, environment: Record<string, string | und
             keypath.splice(emptyStringIndex, 1);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let cursor: Record<string, any> = returnValue;
+        // Goes undefined once the walk reaches a key already holding a primitive:
+        // there is nothing left to descend into, so the rest of the keypath is dropped.
+        let cursor: ConfigObject | undefined = returnValue;
 
         keypath.forEach((subkey, index) => {
             // (check for subkey first so we ignore empty strings)
-            // (check for cursor to avoid assignment to primitive objects)
-            if (!subkey || typeof cursor !== "object") {
+            if (!subkey || cursor === undefined) {
                 return;
             }
 
@@ -69,8 +84,9 @@ const getEnvironment = (prefix: string, environment: Record<string, string | und
             }
 
             // Increment cursor used to track the object at the current depth
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            cursor = cursor[subkey];
+            const next = cursor[subkey];
+
+            cursor = isConfigObject(next) ? next : undefined;
         });
     }
 
@@ -182,38 +198,39 @@ const getConfigFiles = (name: string, home: string, internalCwd: string, stopAt?
  * @returns
  * An object containing the final merged `config` and the ordered list of `files` that were considered.
  */
-// eslint-disable-next-line import/prefer-default-export
 export const rc = (
     name: string,
     options: {
         config?: string;
         cwd?: string;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        defaults?: Record<string, any>;
+        defaults?: ConfigObject;
         home?: string;
         stopAt?: string;
     } = {},
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): { config: Record<string, any>; files: string[] } => {
-    // eslint-disable-next-line no-param-reassign
-    options = {
-        cwd: cwd(),
-        home: homedir(),
-        ...options,
-    };
+): { config: ConfigObject; files: string[] } => {
+    const home = options.home ?? homedir();
+    const internalCwd = options.cwd ?? cwd();
 
     // eslint-disable-next-line @typescript-eslint/naming-convention, sonarjs/no-unused-vars
     const { config: _, ...environment } = getEnvironment(`${name}_`);
 
-    const configFiles = getConfigFiles(name, options.home as string, options.cwd as string, options.stopAt, env[`${name}_config`], options.config);
+    const configFiles = getConfigFiles(name, home, internalCwd, options.stopAt, env[`${name}_config`], options.config);
 
-    const configs: object[] = [];
+    const configs: ConfigObject[] = [];
 
     for (const file of configFiles) {
         const content = readFileSync(file, { buffer: false });
 
         if (isJson(content)) {
-            configs.push(parseJson(stripJsonComments(content)) as object);
+            const parsed = parseJson(stripJsonComments(content));
+
+            // A config file has to be an object at the top level; a bare string,
+            // number or array in one is a mistake worth naming rather than merging.
+            if (!isConfigObject(parsed)) {
+                throw new TypeError(`Expected ${file} to hold a JSON object, found ${parsed === null ? "null" : typeof parsed}.`);
+            }
+
+            configs.push(parsed);
         } else {
             configs.push(parse(content));
         }
@@ -223,3 +240,5 @@ export const rc = (
 
     return { config: merge(options.defaults ?? {}, ...configs), files: configFiles };
 };
+
+export type { ConfigObject, ConfigValue };

--- a/packages/rc/src/utils/is-json.ts
+++ b/packages/rc/src/utils/is-json.ts
@@ -1,11 +1,15 @@
 /**
- * Checks if string is a parseable JSON string.
+ * Checks whether a value reads as parseable JSON.
+ *
+ * Takes `unknown` rather than `string` because file contents are not the only
+ * thing that reaches it, and `JSON.parse` coerces its argument to a string
+ * anyway — `String(value)` just makes that step visible instead of implicit.
  * @param value
  * @returns
  */
-const isJson = (value: string): boolean => {
+const isJson = (value: unknown): boolean => {
     try {
-        JSON.parse(value);
+        JSON.parse(String(value));
     } catch {
         return false;
     }

--- a/packages/semantic-release-clean-package-json/__tests__/index.test.ts
+++ b/packages/semantic-release-clean-package-json/__tests__/index.test.ts
@@ -2,12 +2,13 @@ import { mkdtempSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { stderr, stdout } from "node:process";
 
 import { readFile, readJson, writeFile, writeJson } from "@visulima/fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { publish, success } from "../src";
-import type { CommonContext, PublishContext } from "../src/definitions/context";
+import type { PublishContext } from "../src/definitions/context";
 
 const DEFAULT_PACKAGE_JSON = {
     dependencies: {
@@ -27,27 +28,45 @@ const DEFAULT_PACKAGE_JSON = {
     version: "1.0.0",
 };
 
-const context: Partial<PublishContext> = {
-    branch: {
-        name: "foo",
-    },
-    env: {},
-    lastRelease: {
-        gitHead: "foo",
-        gitTag: "v1.0.0",
-        version: "1.0.0",
-    },
-    logger: {
-        error: vi.fn(),
-        log: vi.fn(),
-        success: vi.fn(),
-    },
-    nextRelease: {
-        gitHead: "foo",
-        gitTag: "2.0.0",
-        type: "major" as const,
-        version: "2.0.0",
-    },
+const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    success: vi.fn(),
+};
+
+/**
+ * A complete plugin context for the given working directory.
+ *
+ * Built in full rather than as a `Partial` that each call site casts back: the
+ * fields semantic-release always provides are cheap to supply, and supplying them
+ * means the fixture is checked against the type instead of asserted past it.
+ * @param cwd The directory the plugin should treat as the package root.
+ * @returns A context accepted by both `publish` and `success`.
+ */
+const createContext = (cwd: string): PublishContext => {
+    return {
+        branch: { name: "foo" },
+        branches: [{ name: "foo" }],
+        commits: [],
+        cwd,
+        env: {},
+        lastRelease: {
+            gitHead: "foo",
+            gitTag: "v1.0.0",
+            version: "1.0.0",
+        },
+        logger,
+        nextRelease: {
+            gitHead: "foo",
+            gitTag: "2.0.0",
+            type: "major",
+            version: "2.0.0",
+        },
+        options: {},
+        releases: [],
+        stderr,
+        stdout,
+    };
 };
 
 describe("semantic-release-clean-package-json", () => {
@@ -70,7 +89,7 @@ describe("semantic-release-clean-package-json", () => {
 
         await writeJson(packageJsonPath, DEFAULT_PACKAGE_JSON);
 
-        await publish({}, { cwd: temporaryDirectoryPath, ...context } as PublishContext);
+        await publish({}, createContext(temporaryDirectoryPath));
 
         await expect(readJson(packageJsonPath)).resolves.toStrictEqual({
             dependencies: {
@@ -82,9 +101,9 @@ describe("semantic-release-clean-package-json", () => {
             },
             version: "1.0.0",
         });
-        expect((context as PublishContext).logger.log).toHaveBeenCalledWith("Created a backup of the package.json file.");
-        expect((context as PublishContext).logger.log).toHaveBeenCalledWith('Removing property "devDependencies"');
-        expect((context as PublishContext).logger.log).toHaveBeenCalledWith('Removing property "eslintConfig"');
+        expect(logger.log).toHaveBeenCalledWith("Created a backup of the package.json file.");
+        expect(logger.log).toHaveBeenCalledWith('Removing property "devDependencies"');
+        expect(logger.log).toHaveBeenCalledWith('Removing property "eslintConfig"');
     });
 
     it("should keep flag from given config", async () => {
@@ -98,7 +117,7 @@ describe("semantic-release-clean-package-json", () => {
             {
                 keep: ["eslintConfig", "devDependencies"],
             },
-            { cwd: temporaryDirectoryPath, ...context } as PublishContext,
+            createContext(temporaryDirectoryPath),
         );
 
         await expect(readJson(packageJsonPath)).resolves.toStrictEqual({
@@ -117,8 +136,8 @@ describe("semantic-release-clean-package-json", () => {
             },
             version: "1.0.0",
         });
-        expect((context as PublishContext).logger.log).toHaveBeenCalledWith("Created a backup of the package.json file.");
-        expect((context as PublishContext).logger.log).toHaveBeenCalledWith(
+        expect(logger.log).toHaveBeenCalledWith("Created a backup of the package.json file.");
+        expect(logger.log).toHaveBeenCalledWith(
             "Keeping the following properties: name, version, private, publishConfig, scripts.preinstall, scripts.install, scripts.postinstall, scripts.dependencies, files, bin, browser, main, man, jsdelivr, unpkg, dependencies, peerDependencies, peerDependenciesMeta, bundledDependencies, optionalDependencies, engines, os, cpu, description, keywords, author, contributors, license, homepage, repository, bugs, funding, type, exports, imports, sponsor, publisher, displayName, categories, galleryBanner, preview, contributes, activationEvents, badges, markdown, qna, extensionPack, extensionDependencies, extensionKind, icon, fesm2020, fesm2015, esm2020, es2020, types, typings, typesVersions, module, sideEffects, eslintConfig, devDependencies",
         );
     });
@@ -130,7 +149,7 @@ describe("semantic-release-clean-package-json", () => {
 
         await writeFile(packageJsonPath, `{\r\n\t"name": "test-package",\r\n\t"version": "1.0.0"\r\n}\r\n`);
 
-        await publish({}, { cwd: temporaryDirectoryPath, ...context } as PublishContext);
+        await publish({}, createContext(temporaryDirectoryPath));
 
         await expect(readFile(packageJsonPath)).resolves.toBe(`{\r\n\t"name": "test-package",\r\n\t"version": "1.0.0"\r\n}\r\n`);
         await expect(readFile(`${temporaryDirectoryPath}/package.json.back`)).resolves.toBe(
@@ -148,28 +167,28 @@ describe("semantic-release-clean-package-json", () => {
             await writeJson(packageJsonPath, DEFAULT_PACKAGE_JSON);
 
             // Run publish to create backup and modify package.json
-            await publish({}, { cwd: temporaryDirectoryPath, ...context } as PublishContext);
+            await publish({}, createContext(temporaryDirectoryPath));
 
             // Run success to restore from backup
-            await success({}, { ...context, cwd: temporaryDirectoryPath } as CommonContext);
+            await success({}, createContext(temporaryDirectoryPath));
 
             // Verify the restored package.json
             const restoredPackageJson = await readJson(packageJsonPath);
 
             expect(restoredPackageJson).toStrictEqual(DEFAULT_PACKAGE_JSON); // This is just mocked without the pnpm or npm semantic-release plugin
 
-            expect((context as PublishContext).logger.log).toHaveBeenCalledWith("Restored modified package.json from backup.");
-            expect((context as PublishContext).logger.error).not.toHaveBeenCalled();
+            expect(logger.log).toHaveBeenCalledWith("Restored modified package.json from backup.");
+            expect(logger.error).not.toHaveBeenCalled();
         });
 
         it("should log error when backup file is not found", async () => {
             expect.assertions(2);
 
             // Run success without creating backup first
-            await success({}, { cwd: temporaryDirectoryPath, ...context } as CommonContext);
+            await success({}, createContext(temporaryDirectoryPath));
 
-            expect((context as PublishContext).logger.error).toHaveBeenCalledWith("No backup package.json found.");
-            expect((context as PublishContext).logger.log).not.toHaveBeenCalledWith("Restored modified package.json from backup.");
+            expect(logger.error).toHaveBeenCalledWith("No backup package.json found.");
+            expect(logger.log).not.toHaveBeenCalledWith("Restored modified package.json from backup.");
         });
 
         it("should handle custom pkgRoot", async () => {
@@ -183,18 +202,18 @@ describe("semantic-release-clean-package-json", () => {
             await writeJson(packageJsonPath, DEFAULT_PACKAGE_JSON);
 
             // Run publish with custom pkgRoot
-            await publish({ pkgRoot: "dist" }, { cwd: temporaryDirectoryPath, ...context } as PublishContext);
+            await publish({ pkgRoot: "dist" }, createContext(temporaryDirectoryPath));
 
             // Run success with custom pkgRoot
-            await success({ pkgRoot: "dist" }, { cwd: temporaryDirectoryPath, ...context } as CommonContext);
+            await success({ pkgRoot: "dist" }, createContext(temporaryDirectoryPath));
 
             // Verify the restored package.json
             const restoredPackageJson = await readJson(packageJsonPath);
 
             expect(restoredPackageJson).toStrictEqual(DEFAULT_PACKAGE_JSON); // This is just mocked without the pnpm or npm semantic-release plugin
 
-            expect((context as PublishContext).logger.log).toHaveBeenCalledWith("Restored modified package.json from backup.");
-            expect((context as PublishContext).logger.error).not.toHaveBeenCalled();
+            expect(logger.log).toHaveBeenCalledWith("Restored modified package.json from backup.");
+            expect(logger.error).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/semantic-release-clean-package-json/src/index.ts
+++ b/packages/semantic-release-clean-package-json/src/index.ts
@@ -9,6 +9,12 @@ import type { CommonContext, PublishContext } from "./definitions/context";
 import type { PluginConfig } from "./definitions/plugin-config";
 import getPackage from "./utils/get-package";
 
+/** A value as it can appear inside a `package.json`. */
+type ManifestValue = boolean | null | number | ReadonlyArray<ManifestValue> | string | { [key: string]: ManifestValue };
+
+/** A parsed `package.json`, keyed by field name. */
+type ManifestObject = { [key: string]: ManifestValue };
+
 /**
  * Clean the `package.json` that will be published by removing properties that are not relevant for the
  * published artifact. All properties defined in `defaultKeepProperties` plus any properties provided
@@ -90,10 +96,15 @@ export const success = async (pluginConfig: PluginConfig, context: CommonContext
         const packageJson = await getPackage(pluginConfig, context);
 
         const backupContent = await readFile(backupPackageJson);
-        const backupPackageJsonContent = (await readJson(backupPackageJson)) as Record<string, unknown>;
+        const backupPackageJsonContent = await readJson<ManifestObject>(backupPackageJson);
 
-        // Overwrite the version from the backup package.json
-        backupPackageJsonContent.version = packageJson.version;
+        // Overwrite the version from the backup package.json. A manifest without one
+        // loses the field entirely, which is what serializing `undefined` did before.
+        if (packageJson.version === undefined) {
+            delete backupPackageJsonContent.version;
+        } else {
+            backupPackageJsonContent.version = packageJson.version;
+        }
 
         await writeFile(join(cwd, "package.json"), serializeManifest(backupPackageJsonContent, backupContent));
 

--- a/packages/semantic-release-clean-package-json/src/utils/get-package.ts
+++ b/packages/semantic-release-clean-package-json/src/utils/get-package.ts
@@ -72,7 +72,7 @@ const getPackage = async (
 
         return packageJson;
     } catch (error: unknown) {
-        if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
             const semanticError = getError("ENOPKG");
 
             throw new AggregateError([semanticError], semanticError.message, { cause: error });


### PR DESCRIPTION
Stacked on #420 — that PR clears the audit gate, which is what let the lint job get far enough to report anything at all. Review this one after it.

Both packages used `as` to get types the code never established. That is what `@typescript-eslint/no-unsafe-type-assertion` and `@typescript-eslint/no-restricted-types` were reporting: 39 errors between them.

### rc

- `Record<string, any>` and `object` become `ConfigObject`/`ConfigValue`, a recursive pair describing what a config tree actually holds. Both are exported, so callers get the shape instead of `any`.
- The env walk keeps its behaviour — stop descending once a key holds a primitive — but expresses it by letting the cursor go `undefined`, rather than a `typeof cursor !== "object"` guard on a type that claimed it was always an object.
- A JSON config that parses to a string, number or array now throws with the file named. Previously it was asserted to be an object and merged as one.
- `isJson` takes `unknown`. `JSON.parse` coerces its argument to a string regardless, so a test feeding it numbers and functions was always the real contract; saying so removes the two casts that hid it. Behaviour is unchanged for every input in that test, `5` included.

### clean-package-json

- `readJson<ManifestObject>` replaces a cast on the return value.
- `"code" in error` already narrows, so the `NodeJS.ErrnoException` assertion after it was doing nothing.
- The test built a `Partial<PublishContext>` and cast it back at **19 call sites**. A factory supplying every required field removes all 19 — the fixture is checked against the type now instead of asserted past it.

### One disable kept, with its reason

The three `vi.mock` calls in `rc.test.ts` keep a `no-restricted-syntax` disable and a comment explaining it: the precedence rules under test span `/etc/bemrc` and `/.bemrc`, and a test process cannot create files there. The two mocks in `rc-unmocked.test.ts` *were* replaceable and are gone — it chdirs into a real temp tree and passes `home` through the public option.

### Verification

Per package, locally: `eslint .` clean, `tsc --noEmit` clean, 36 + 6 tests passing.

### This does not turn the gate green

CI runs `nx affected --target=lint:eslint --nxBail`, so it stopped at the first two failing projects — which is why 39 was the number visible. The rest of the workspace carries the same backlog:

| Project | Errors |
| --- | --- |
| `rc` | 17 → **0** |
| `semantic-release-clean-package-json` | 22 → **0** |
| `semantic-release-pnpm` | 146 |
| `multi-semantic-release` | 275 |
| `semantic-release-preset` | 0 |

421 remain, overwhelmingly the same two rules (320 × `no-unsafe-type-assertion`, 64 × `no-restricted-types`), plus 28 × `no-restricted-syntax` and 9 × `e18e/ban-dependencies` — the last of which asks for dependency swaps (`semver` → `verkit`) rather than a type fix, and is a judgement call rather than a lint cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf
