### PR TITLE
fix(deps): drop the duplicated browserslist override key

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,7 +316,6 @@ overrides:
   axios@>=1.15.2 <1.18.0: ^1.20.0
   axios@>=1.7.0 <1.18.0: ^1.20.0
   body-parser@>=2.2.0 <2.2.1: '>=2.3.0'
-  browserslist@<=4.28.6: '>=4.28.7'
   brace-expansion@<1.1.13: '>=5.0.9'
   brace-expansion@>=2.0.0 <2.0.3: '>=5.0.9'
   brace-expansion@>=3.0.0 <5.0.7: ^5.0.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -216,7 +216,6 @@ overrides:
   axios@>=1.15.2 <1.18.0: ^1.20.0
   axios@>=1.7.0 <1.18.0: ^1.20.0
   body-parser@>=2.2.0 <2.2.1: '>=2.3.0'
-  browserslist@<=4.28.6: '>=4.28.7'
   brace-expansion@<1.1.13: '>=5.0.9'
   brace-expansion@>=2.0.0 <2.0.3: '>=5.0.9'
   brace-expansion@>=3.0.0 <5.0.7: ^5.0.9


### PR DESCRIPTION
`main` cannot install right now. #420 and #426 each added `browserslist@<=4.28.6: '>=4.28.7'`, and merging both left the key twice — once in `pnpm-workspace.yaml`, once in the `overrides` block of `pnpm-lock.yaml`. YAML forbids a duplicated mapping key, so pnpm refuses to read either file:

```
[ERROR] duplicated mapping key (225:3)
   225 |   browserslist@<=4.28.6: '>=4.28.7'
---------^

[ERR_PNPM_BROKEN_LOCKFILE] The lockfile at ".../pnpm-lock.yaml" is broken:
duplicated mapping key (325:3)
```

Every job that reaches `pnpm install` dies there, which is all of them.

The two entries are byte-identical, so this drops the first of each pair. The survivor sits in the alphabetical position the rest of the block uses — after `brace-expansion`, before `chrono-node` — and the resolved tree is unchanged.

After it: `pnpm install --frozen-lockfile` succeeds, and `pnpm audit --audit-level=moderate` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependency configuration by removing a version-specific Browserslist override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->