### PR TITLE
fix(deps): dedupe browserslist override

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -222,7 +222,6 @@ overrides:
   brace-expansion@>=3.0.0 <5.0.7: ^5.0.9
   brace-expansion@>=4.0.0 <5.0.9: '>=5.0.9'
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.9'
-  browserslist@<=4.28.6: '>=4.28.7'
   chrono-node@<2.2.4: '>=2.10.1'
   defu@<=6.1.4: '>=6.1.7'
   diff@>=5.0.0 <5.2.2: '>=9.0.0'


### PR DESCRIPTION
Removes the duplicate browserslist override entry that made pnpm fail with 'duplicated mapping key (225:3)', breaking the Semantic Release workflow.