### PR TITLE
fix(deps): regenerate lockfile to drop duplicated override key

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,7 +322,6 @@ overrides:
   brace-expansion@>=3.0.0 <5.0.7: ^5.0.9
   brace-expansion@>=4.0.0 <5.0.9: '>=5.0.9'
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.9'
-  browserslist@<=4.28.6: '>=4.28.7'
   chrono-node@<2.2.4: '>=2.10.1'
   defu@<=6.1.4: '>=6.1.7'
   diff@>=5.0.0 <5.2.2: '>=9.0.0'


### PR DESCRIPTION
The pnpm-lock.yaml overrides block carried a duplicated browserslist entry (from the earlier merge), which made the Semantic Release workflow fail with ERR_PNPM_BROKEN_LOCKFILE (duplicated mapping key 325:3). Regenerated the lockfile from the deduped workspace config.