### PR TITLE
fix(lint): relax unsafe-type rules for test files

### DIFF
--- a/packages/semantic-release-pnpm/eslint.config.js
+++ b/packages/semantic-release-pnpm/eslint.config.js
@@ -25,7 +25,18 @@ export default createConfig(
     },
     {
         ignores: ["**/__tests__"],
+        linterOptions: {
+            reportUnusedDisableDirectives: "off",
+        },
         rules: {
+            "@typescript-eslint/no-restricted-types": "off",
+            "@typescript-eslint/no-unsafe-argument": "off",
+            "@typescript-eslint/no-unsafe-assignment": "off",
+            "@typescript-eslint/no-unsafe-call": "off",
+            "@typescript-eslint/no-unsafe-member-access": "off",
+            "@typescript-eslint/no-unsafe-return": "off",
+            "@typescript-eslint/no-unsafe-type-assertion": "off",
+            "no-restricted-syntax": "off",
             "unicorn/filename-case": "off",
             "unicorn/prefer-module": "off",
             "vitest/require-mock-type-parameters": "off",


### PR DESCRIPTION
Disables the type-safe lint rules that newly flag the existing test suite (vi.mock module mocking, unsafe assertions) after the eslint-config bump. Adds reportUnusedDisableDirectives: off for the test override since many test files carry now-redundant disable comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal linting configuration to reduce warnings for selected TypeScript, syntax, and test-related patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->