### PR TITLE
ci(release): skip nx cache compression on lockfile-only releases

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -78,6 +78,7 @@ jobs:
 
             - name: "Prepare nx cache"
               shell: "bash"
+              if: "hashFiles('.nx/cache/**') != ''"
               run: "tar -cf - .nx/cache | lz4 > /tmp/nx_cache.tar.lz4" # compress nx cache
 
             - name: "Upload code coverage to codecov"


### PR DESCRIPTION
The Semantic Release workflow failed on the d2cbe33 merge: a lockfile-only change leaves the nx affected graph empty, .nx/cache is never created, and the unconditional 'Prepare nx cache' tar step errored the whole run.

Guard it with hashFiles(', the same fix already merged for the test and preview-release workflows.